### PR TITLE
Fix summary overlay hidden state

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
       transition: opacity 0.3s;
     }
 
-    .hidden {
+    #summary.hidden {
       display: none;
     }
 


### PR DESCRIPTION
## Summary
- ensure the summary overlay is hidden on game start

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_688b32418438832c9ab11c7b5ba5cdef