### PR TITLE
Update layout and color for target heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
       --primary: #ff6b3d;
       --secondary: #734c39;
       --muffin-color: #ff6b3d;
-      --chihuahua-color: #007bff;
+      --chihuahua-color: #ff8c42;
 
       --success: #28a745;
       --error: #dc3545;
@@ -63,6 +63,10 @@
 
     .target-chihuahua {
       color: var(--chihuahua-color);
+    }
+
+    .prefix {
+      display: block;
     }
 
     .grid {
@@ -194,7 +198,7 @@
 </head>
 <body>
   <main class="container">
-    <h1 id="mode">Find the <span id="target-name">Loading...</span></h1>
+    <h1 id="mode"><span class="prefix">Find the</span><br><span id="target-name">Loading...</span></h1>
     <div id="hud">
       <span id="time-display">Time: <span id="timer">20</span>s</span>
       <span>Score: <span id="score">0</span></span>


### PR DESCRIPTION
## Summary
- move the target span to its own line to avoid cramped UI
- switch chihuahua color to a warm orange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b38904578832cb072ac8b401a8881