### PR TITLE
Adjust 'Find the' header style

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@
     }
 
     .prefix {
-      display: block;
+      display: inline;
+      font-size: 0.5em;
     }
 
     .grid {
@@ -228,7 +229,7 @@
 </head>
 <body>
   <main class="container">
-    <h1 id="mode"><span class="prefix">Find the</span><br><span id="target-name">Loading...</span></h1>
+    <h1 id="mode"><span class="prefix">Find the&nbsp;</span><span id="target-name">Loading...</span></h1>
     <div id="hud">
       <span id="time-display">Time: <span id="timer">20</span>s</span>
       <span>Score: <span id="score">0</span></span>


### PR DESCRIPTION
## Summary
- reduce header spacing by removing `<br>` between `Find the` and the target name
- make the `Find the` prefix half-sized and inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b3b95373c832cb4398382e7eb6d1f