### PR TITLE
Improve intro text and timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,9 +252,9 @@
     <p>Tap anywhere to play again</p>
   </div>
   <div id="intro" class="show no-click">
-    <h2>How to Play</h2>
-    <p>Find the target image in the grid.</p>
-    <p>Tap anywhere to start</p>
+    <h2>Welcome, Design Star ✨</h2>
+    <p>As the chief designer for Google, Apple, Figma &amp; Canva, show off your eye for detail!</p>
+    <p>Tap anywhere to begin 👆</p>
   </div>
 
   <script>
@@ -404,7 +404,7 @@
     setTimeout(() => {
       introEl.classList.remove("no-click");
       introClickable = true;
-    }, 2000);
+    }, 1000);
   }
 
   function hideIntro() {


### PR DESCRIPTION
## Summary
- update intro overlay wording for a cuter design touch
- make intro overlay clickable after 1 second instead of 2 seconds

## Testing
- `python3 -m py_compile rename_images.py`

------
https://chatgpt.com/codex/tasks/task_e_688c7fa1d418832cb0b97094e7776bad