### PR TITLE
Adjust muffin color and preload 3x5 images

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       --card-bg: #fffaf5;
       --primary: #ff6b3d;
       --secondary: #734c39;
-      --muffin-color: #ff6b3d;
+      --muffin-color: #d16aff;
       --chihuahua-color: #ff8c42;
 
       --success: #28a745;
@@ -661,6 +661,7 @@
           score++;
           if (score === MEDIUM_MODE_THRESHOLD) {
             preloadQueue.length = 0;
+            ensurePreload();
           }
           timeLeft += 2;
           updateHUD();


### PR DESCRIPTION
## Summary
- update muffin text color to a pastel purple
- when switching to 3x5 mode, start preloading images immediately

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ce4493fd8832c8d5466e68ca2df59