### PR TITLE
feat: inline hard mode indicator with hud

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,7 +565,7 @@
 
     /* 困難模式指示器 */
     #difficulty-indicator {
-      margin-bottom: var(--space-md);
+      margin: 0;
       animation: slideDown 0.6s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
@@ -1588,15 +1588,6 @@
         <span id="target-name">Loading...</span>
       </h1>
       
-      <!-- Hard Mode Indicator -->
-      <div id="difficulty-indicator" class="hidden">
-        <div class="difficulty-badge">
-          <span class="fire-icon">🔥</span>
-          <span>Hard Mode</span>
-          <span class="target-count">Find <span id="targets-needed">2</span>!</span>
-        </div>
-      </div>
-      
       <!-- 🔥 Hell Mode Indicator -->
       <div id="hell-indicator" class="hidden">
         <div class="hell-badge">
@@ -1605,12 +1596,21 @@
           <span class="hell-target-count">Find <span id="hell-targets-needed">3</span>!</span>
         </div>
       </div>
-      
+
       <div id="hud">
         <div id="time-display">
           <span style="font-size: 0.9rem; opacity: 0.8;">Time:</span>
           <span id="timer">30</span>s
           <span id="time-change"></span>
+        </div>
+
+        <!-- Hard Mode Indicator -->
+        <div id="difficulty-indicator" class="hidden">
+          <div class="difficulty-badge">
+            <span class="fire-icon">🔥</span>
+            <span>Hard Mode</span>
+            <span class="target-count">Find <span id="targets-needed">2</span>!</span>
+          </div>
         </div>
         
         <!-- Hard Mode Progress Indicator - In HUD -->


### PR DESCRIPTION
## Summary
- show Hard Mode "Find 2" badge inside the HUD so it lines up with time/progress/score
- remove extra margin from the Hard Mode indicator for cleaner mobile layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2054e944832c94bb4f9e527525d1