### PR TITLE
Add Muffind chihuahua game SEO keywords

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   
   <!-- 🎯 Core SEO Meta Tags -->
   <title>Muffind - Can You Tell Muffins from Chihuahuas? | Free Online Game</title>
-  <meta name="description" content="Play Muffind, the viral image recognition game! Test your skills distinguishing cute chihuahuas from delicious muffins. Free online puzzle game with hard mode and hell mode challenges.">
-  <meta name="keywords" content="muffin vs chihuahua game, image recognition puzzle, viral online game, free browser game, muffin or chihuahua challenge, visual puzzle game, pattern recognition, cognitive training, fun quiz game, educational game">
+  <meta name="description" content="Play Muffind, the viral chihuahua game! Test your skills distinguishing cute chihuahuas from delicious muffins. Free online puzzle game with hard mode and hell mode challenges.">
+  <meta name="keywords" content="muffind chihuahua game, chihuahua game, muffin vs chihuahua game, muffin chihuahua game, image recognition puzzle, viral online game, free browser game, muffin or chihuahua challenge, visual puzzle game, pattern recognition, cognitive training, fun quiz game, educational game">
   
   <!-- 🌍 Multilingual SEO -->
   <meta name="description" lang="es" content="¡Juega Muffind! ¿Puedes distinguir entre muffins deliciosos y chihuahuas adorables? Juego viral gratis de reconocimiento de imágenes con modo difícil.">
@@ -1675,7 +1675,9 @@
     <article>
       <h2>About Muffind - The Viral Muffin vs Chihuahua Game</h2>
       <p>Muffind is the internet's most popular image recognition puzzle game that challenges players to distinguish between adorable chihuahuas and delicious muffins. This viral browser-based game has taken social media by storm, testing visual perception skills and pattern recognition abilities.</p>
-      
+
+      <p>The Muffind chihuahua game offers a unique challenge for players searching for a fun chihuahua game that combines cuteness with brain-training puzzles.</p>
+
       <section>
         <h3>Game Features and Modes</h3>
         <ul>


### PR DESCRIPTION
## Summary
- highlight Muffind as a chihuahua game in main meta description and keyword list
- add hidden SEO paragraph emphasizing the Muffind chihuahua game experience

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8413610c832c8bfef1796634672b